### PR TITLE
Support native overlaybd commit snapshots

### DIFF
--- a/cmd/nerdctl/container/container_commit.go
+++ b/cmd/nerdctl/container/container_commit.go
@@ -42,7 +42,7 @@ func CommitCommand() *cobra.Command {
 	cmd.Flags().StringP("message", "m", "", "Commit message")
 	cmd.Flags().StringArrayP("change", "c", nil, "Apply Dockerfile instruction to the created image (supported directives: [CMD, ENTRYPOINT])")
 	cmd.Flags().BoolP("pause", "p", true, "Pause container during commit")
-	cmd.Flags().StringP("compression", "", "gzip", "commit compression algorithm (zstd or gzip)")
+	cmd.Flags().StringP("compression", "", "gzip", "commit compression algorithm (zstd, gzip, or uncompressed)")
 	cmd.Flags().String("format", "docker", "Format of the committed image (docker or oci)")
 	cmd.Flags().Bool("estargz", false, "Convert the committed layer to eStargz for lazy pulling")
 	cmd.Flags().Int("estargz-compression-level", 9, "eStargz compression level (1-9)")
@@ -81,8 +81,8 @@ func commitOptions(cmd *cobra.Command) (types.ContainerCommitOptions, error) {
 	if err != nil {
 		return types.ContainerCommitOptions{}, err
 	}
-	if com != string(types.Zstd) && com != string(types.Gzip) {
-		return types.ContainerCommitOptions{}, errors.New("--compression param only supports zstd or gzip")
+	if com != string(types.Zstd) && com != string(types.Gzip) && com != string(types.Uncompressed) {
+		return types.ContainerCommitOptions{}, errors.New("--compression param only supports zstd, gzip, or uncompressed")
 	}
 
 	format, err := cmd.Flags().GetString("format")

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -412,8 +412,9 @@ type ContainerCommitOptions struct {
 type CompressionType string
 
 const (
-	Zstd CompressionType = "zstd"
-	Gzip CompressionType = "gzip"
+	Zstd         CompressionType = "zstd"
+	Gzip         CompressionType = "gzip"
+	Uncompressed CompressionType = "uncompressed"
 )
 
 type ImageFormat string

--- a/pkg/imgutil/commit/commit.go
+++ b/pkg/imgutil/commit/commit.go
@@ -538,7 +538,10 @@ func applyDiffLayer(ctx context.Context, name string, baseImg ocispec.Image, sn 
 		parent = identity.ChainID(baseImg.RootFS.DiffIDs).String()
 	)
 
-	mount, err := sn.Prepare(ctx, key, parent)
+	labels := map[string]string{
+		"containerd.io/snapshot/type": "image",
+	}
+	mount, err := sn.Prepare(ctx, key, parent, snapshots.WithLabels(labels))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds support for uncompressed layer media type (which overlaybd uses) and passes a special
label to the snapshotter to let it know that the snapshot being prepared is not for a writable layer, but for
constructing an image (RO).